### PR TITLE
Remove F45 section from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,35 +80,6 @@
                             </div>
                         </div>
 
-                        <!-- F45 Project -->
-                        <div class="bg-gradient-to-r from-purple-50 to-pink-50 p-6 rounded-xl border border-purple-200 hover:shadow-lg transition-shadow">
-                            <div class="flex items-start justify-between">
-                                <div class="flex-1">
-                                    <div class="flex items-center mb-3">
-                                        <div class="bg-purple-100 p-2 rounded-lg mr-3">
-                                            <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
-                                            </svg>
-                                        </div>
-                                        <div>
-                                            <h3 class="text-xl font-bold text-purple-900">F45 Training</h3>
-                                            <p class="text-sm text-purple-600">Fitness Studio Management System</p>
-                                        </div>
-                                    </div>
-                                    
-                                    <p class="text-sm text-slate-600 mb-4">Comprehensive fitness studio management solution with member tracking, class scheduling, and performance analytics.</p>
-                                </div>
-                            </div>
-                            
-                            <div class="flex items-center justify-between pt-4 border-t border-purple-200">
-                                <div class="flex items-center space-x-4">
-                                    <span class="bg-purple-100 text-purple-800 px-3 py-1 rounded-full text-xs font-medium">Portfolio</span>
-                                </div>
-                                <a href="./f45.html" class="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-2 rounded-lg hover:from-purple-700 hover:to-pink-700 transition-all font-medium">
-                                    View Project →
-                                </a>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Removes the F45 Training project section from the main index page as requested in issue #2.

Generated with [Claude Code](https://claude.ai/code)