### PR TITLE
Hide pricing tab and copy implementation timeline

### DIFF
--- a/vita.html
+++ b/vita.html
@@ -170,7 +170,6 @@
                 <a href="#" class="nav-link" data-section="dataIntegration">Monthly Reporting</a>
                 <a href="#" class="nav-link" data-section="roadmap">Implementation Plan</a>
                 <a href="#" class="nav-link" data-section="compliance">Compliance & Security</a>
-                <a href="#" class="nav-link" data-section="nextSteps">Pricing & Timeline</a>
             </nav>
         </div>
     </header>
@@ -536,6 +535,33 @@
             </div>
              <div id="phaseDetailsContainer" class="mt-6">
                 </div>
+            
+            <!-- 🗓️ Implementation Timeline Section (copied from Pricing & Timeline) -->
+            <div class="card mt-6">
+                <h3 class="text-2xl font-semibold text-slate-800 mb-4">🗓️ Implementation Timeline</h3>
+                <div class="grid md:grid-cols-4 gap-4">
+                    <div class="text-center p-4 bg-blue-50 rounded-lg">
+                        <div class="text-2xl font-bold text-blue-600 mb-2">Week 1-2</div>
+                        <h4 class="font-semibold text-blue-800 mb-2">Discovery</h4>
+                        <p class="text-sm text-blue-700">Requirements analysis, system audit, compliance review</p>
+                    </div>
+                    <div class="text-center p-4 bg-purple-50 rounded-lg">
+                        <div class="text-2xl font-bold text-purple-600 mb-2">Week 3-6</div>
+                        <h4 class="font-semibold text-purple-800 mb-2">Development</h4>
+                        <p class="text-sm text-purple-700">API integration, RHPA modules, ADP connection</p>
+                    </div>
+                    <div class="text-center p-4 bg-orange-50 rounded-lg">
+                        <div class="text-2xl font-bold text-orange-600 mb-2">Week 7-8</div>
+                        <h4 class="font-semibold text-orange-800 mb-2">Testing</h4>
+                        <p class="text-sm text-orange-700">UAT, compliance validation, performance testing</p>
+                    </div>
+                    <div class="text-center p-4 bg-green-50 rounded-lg">
+                        <div class="text-2xl font-bold text-green-600 mb-2">Week 9</div>
+                        <h4 class="font-semibold text-green-800 mb-2">Go Live</h4>
+                        <p class="text-sm text-green-700">Deployment, staff training, monitoring setup</p>
+                    </div>
+                </div>
+            </div>
         </section>
 
         <section id="compliance" class="section-content">
@@ -610,7 +636,7 @@
             </div>
         </section>
 
-        <section id="nextSteps" class="section-content">
+        <section id="nextSteps" class="section-content" style="display: none;">
             <h2 class="text-3xl font-semibold text-slate-800 mb-6">Investment & Timeline</h2>
             
             <!-- Pricing Strategy Card -->


### PR DESCRIPTION
Fixes #1

This PR addresses the requirements to:
- Copy the 🗓️ Implementation Timeline Week 1-2 section to the Implementation Plan
- Hide the pricing & timeline page

## Changes Made
- Added implementation timeline section to the roadmap/implementation plan area
- Removed "Pricing & Timeline" tab from navigation
- Hidden pricing section completely from view

Generated with [Claude Code](https://claude.ai/code)