### PR TITLE
remove part of index

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,6 @@
             </div>
             <h1 class="text-5xl font-bold text-slate-800 mb-6">Secure Canadian AI Platform<br><span class="text-sky-600">for Healthcare Organizations</span></h1>
             <p class="text-2xl text-slate-600 mb-8">Government-Grade Security Meets Healthcare AI Automation</p>
-            <div class="bg-gradient-to-r from-red-50 to-red-100 border border-red-200 rounded-lg p-4 max-w-2xl mx-auto mb-8">
-                <p class="text-lg font-semibold text-red-800">Asked Monday, Live Friday</p>
-                <p class="text-red-600">Agentic AI workflows shipped in days, not months</p>
-            </div>
         </div>
 
         <!-- Founder Section -->


### PR DESCRIPTION
Removes promotional text from hero section as requested in issue #8.

Removed the red gradient banner containing:
- "Asked Monday, Live Friday"
- "Agentic AI workflows shipped in days, not months"

Closes #8

Generated with [Claude Code](https://claude.ai/code)